### PR TITLE
Feats:  speech-based controls & improved help menu.

### DIFF
--- a/src/molabel/static/widget.css
+++ b/src/molabel/static/widget.css
@@ -4,6 +4,7 @@
     padding: 1rem;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     position: relative;
+    transition: all 0.2s ease-in-out;
 }
 
 .molabel-header {
@@ -18,7 +19,6 @@
     color: #6c757d;
     font-size: 0.9rem;
 }
-
 
 .molabel-progress-container {
     margin-bottom: 1rem;
@@ -42,9 +42,19 @@
 .molabel-example {
     border-radius: 4px;
     padding: 1rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1rem;
     min-height: 150px;
     overflow-x: auto;
+}
+
+.molabel-last-choice {
+    text-align: center;
+    height: 1.5em;
+    /* Reserve space to prevent layout shift */
+    margin-bottom: 0.5rem;
+    color: #495057;
+    font-style: italic;
+    font-weight: 500;
 }
 
 .molabel-controls {
@@ -67,7 +77,7 @@
 
 .molabel-btn:hover:not(:disabled) {
     transform: translateY(-1px);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .molabel-btn:disabled {
@@ -128,7 +138,9 @@
     margin: 0;
 }
 
-.molabel-mic-btn {
+.molabel-mic-btn,
+.molabel-speech-select-btn,
+.molabel-help-btn {
     background: none;
     border: 1px solid #ced4da;
     border-radius: 3px;
@@ -136,14 +148,19 @@
     font-size: 0.8rem;
     padding: 0.2rem 0.4rem;
     transition: all 0.2s;
+    line-height: 1.2;
 }
 
-.molabel-mic-btn:hover:not(:disabled) {
+.molabel-mic-btn:hover:not(:disabled),
+.molabel-speech-select-btn:hover:not(:disabled),
+.molabel-help-btn:hover:not(:disabled) {
     background: #f8f9fa;
     border-color: #80bdff;
 }
 
-.molabel-mic-btn:disabled {
+.molabel-mic-btn:disabled,
+.molabel-speech-select-btn:disabled,
+.molabel-help-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
 }
@@ -163,13 +180,28 @@
     background: #dc3545;
     border-color: #dc3545;
     color: white;
-    animation: pulse 1s infinite;
+    animation: pulse 1.2s infinite;
+}
+
+.molabel-speech-select-btn.active {
+    background: #007bff;
+    border-color: #007bff;
+    color: white;
+    animation: pulse 1.2s infinite;
 }
 
 @keyframes pulse {
-    0% { opacity: 1; }
-    50% { opacity: 0.7; }
-    100% { opacity: 1; }
+    0% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.7;
+    }
+
+    100% {
+        opacity: 1;
+    }
 }
 
 .molabel-notes {
@@ -185,85 +217,31 @@
 .molabel-notes:focus {
     outline: none;
     border-color: #80bdff;
-    box-shadow: 0 0 0 0.2rem rgba(0,123,255,.25);
+    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, .25);
 }
 
 .molabel-notes.recording {
     border-color: #dc3545;
-    box-shadow: 0 0 0 0.2rem rgba(220,53,69,.25);
+    box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, .25);
 }
 
-.molabel-shortcuts {
-    margin-top: 1rem;
-    color: #6c757d;
-    font-size: 0.85rem;
+.molabel-container.speech-selection-active {
+    outline: 2px solid #007bff;
+    outline-offset: 2px;
+    box-shadow: 0 0 10px rgba(0, 123, 255, .5);
 }
 
-.shortcuts-details {
-    margin-top: 0.5rem;
-}
-
-.shortcuts-details summary {
-    cursor: pointer;
-    font-size: 0.9rem;
-    color: #6c757d;
-}
-
-.shortcuts-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.8rem;
-    margin-top: 0.5rem;
-}
-
-.shortcuts-table th {
-    background: #f8f9fa;
-    padding: 0.5rem;
-    text-align: left;
-    font-weight: 600;
-    color: #495057;
-    border-bottom: 1px solid #dee2e6;
-}
-
-.shortcuts-table td {
-    padding: 0.5rem;
-    border-bottom: 1px solid #f1f3f4;
-    vertical-align: middle;
-}
-
-.shortcuts-table tr:last-child td {
-    border-bottom: none;
-}
-
-.action-name {
-    font-weight: 500;
-    color: #495057;
-    text-transform: capitalize;
-}
-
-.shortcut-key {
-    font-family: 'SF Mono', 'Monaco', 'Consolas', 'Roboto Mono', monospace;
-    background: #f8f9fa;
-    border: 1px solid #dee2e6;
-    border-radius: 3px;
-    padding: 0.1rem 0.3rem;
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: #495057;
-    margin-right: 0.5rem;
-}
-
-
-/* Visual feedback for actions */
 @keyframes button-flash {
     0% {
         transform: scale(1);
         box-shadow: 0 0 0 0 var(--feedback-color);
     }
+
     50% {
         transform: scale(1.05);
         box-shadow: 0 0 15px 3px var(--feedback-color);
     }
+
     100% {
         transform: scale(1);
         box-shadow: 0 0 0 0 var(--feedback-color);
@@ -290,3 +268,194 @@
     animation: button-flash 0.3s ease-out;
 }
 
+@media (prefers-color-scheme: dark) {
+    .molabel-example {
+        color: #e0e0e0;
+    }
+
+    .molabel-last-choice {
+        color: #b0b0b0;
+    }
+
+    .molabel-status {
+        color: #9e9e9e;
+    }
+}
+
+
+.molabel-help-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease-in-out, visibility 0s 0.2s;
+}
+
+.molabel-help-overlay.is-visible {
+    opacity: 1;
+    visibility: visible;
+    transition: opacity 0.2s ease-in-out;
+}
+
+.molabel-help-content {
+    background-color: var(--card, #ffffff);
+    color: var(--card-foreground, #0f172a);
+    border: 1px solid var(--border, #e2e8f0);
+    border-radius: var(--radius, 8px);
+    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.2), 0 8px 10px -6px rgba(0, 0, 0, 0.2);
+    padding: 1.5rem;
+    width: 100%;
+    max-width: 30rem;
+    margin: 1rem;
+    position: relative;
+}
+
+@media (prefers-color-scheme: dark) {
+    .molabel-help-content {
+        background-color: var(--card, #252927);
+        color: var(--card-foreground, #c0c6c3);
+        border-color: var(--border, #3b403e);
+    }
+}
+
+.molabel-help-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    text-align: center;
+    margin: -1.5rem -1.5rem 1rem -1.5rem;
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid var(--border, #e2e8f0);
+}
+
+.molabel-help-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.molabel-help-table th,
+.molabel-help-table td {
+    padding: 0.6rem 0.5rem;
+    text-align: left;
+    vertical-align: middle;
+    border-bottom: 1px solid var(--border, #e2e8f0);
+}
+
+.molabel-help-table th {
+    font-weight: 600;
+    color: var(--muted-foreground, #64748b);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.molabel-help-table tr:last-child td {
+    border-bottom: none;
+}
+
+.molabel-help-table .action-name-cell {
+    font-weight: 500;
+    text-transform: capitalize;
+    padding-left: 0;
+}
+
+.molabel-help-table .shortcut-cell {
+    text-align: center;
+    padding-right: 0;
+}
+
+kbd.molabel-key {
+    background: #f7f7f7;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    box-shadow: 0 3px 0 #bbb, 0 4px 1px #999, inset 0 1px 1px #fff;
+    color: #333;
+    display: inline-block;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 10px;
+    font-weight: 500;
+    line-height: 1;
+    padding: 8px 12px;
+    text-shadow: 0 1px 0 #fff;
+    transition: all 0.07s ease-in-out;
+    transform: translateY(0);
+}
+
+kbd.molabel-key:active {
+    transform: translateY(3px);
+    box-shadow: 0 0px 0 #bbb, 0 1px 0 #999, inset 0 1px 1px #fff;
+}
+
+@media (prefers-color-scheme: dark) {
+    kbd.molabel-key {
+        background-color: #3a3a3a;
+        border-color: #111;
+        box-shadow: 0 3px 0 #111, 0 4px 1px #000, inset 0 1px 0 #555;
+        color: #eee;
+        text-shadow: 0 1px 0 #000;
+    }
+
+    kbd.molabel-key:active {
+        box-shadow: 0 0px 0 #111, 0 1px 0 #000, inset 0 1px 0 #555;
+    }
+}
+
+.key-separator {
+    margin: 0 0.1rem;
+    font-weight: 500;
+    color: var(--muted-foreground, #64748b);
+}
+
+.gamepad-btn {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    position: relative;
+    border: 0;
+    outline: none;
+    font-family: 'Roboto', 'Open Sans', Helvetica, Arial, sans-serif;
+    font-size: 12px;
+    font-weight: bold;
+    text-transform: uppercase;
+    user-select: none;
+    transition: all .1s ease;
+    background-image: linear-gradient(#5f5e60, #3C3D3F);
+    box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, .1);
+    filter: drop-shadow(0 2px 2px rgba(0, 0, 0, .5));
+    color: white;
+}
+
+.gamepad-btn-round {
+    width: 20px;
+    height: 20px;
+    border-radius: 100%;
+}
+
+.gamepad-btn-rect {
+    width: 31px;
+    height: 21px;
+    border-radius: 3px;
+}
+
+.gamepad-btn-trigger {
+    width: 31px;
+    height: 21px;
+    border-radius: 3px 8px 8px 8px;
+}
+
+.gamepad-btn .gamepad-view-icon {
+    width: 15px;
+    height: 15px;
+    stroke: currentColor;
+    stroke-width: 3px;
+}

--- a/src/molabel/static/widget.js
+++ b/src/molabel/static/widget.js
@@ -1,680 +1,882 @@
-function render({ model, el }) {
-  // Create the main container
-  const container = document.createElement('div');
-  container.className = 'molabel-container';
-  container.tabIndex = 0; // Make container focusable via tab key only
-  
-  // Create header with status and settings
-  const header = document.createElement('div');
-  header.className = 'molabel-header';
-  
-  const status = document.createElement('div');
-  status.className = 'molabel-status';
-  
-  header.appendChild(status);
-  
-  // Create example display
-  const exampleContainer = document.createElement('div');
-  exampleContainer.className = 'molabel-example';
-  
-  // Create controls
-  const controls = document.createElement('div');
-  controls.className = 'molabel-controls';
-  
-  const prevBtn = document.createElement('button');
-  prevBtn.textContent = 'Previous';
-  prevBtn.className = 'molabel-btn molabel-btn-prev';
-  
-  const yesBtn = document.createElement('button');
-  yesBtn.textContent = 'Yes';
-  yesBtn.className = 'molabel-btn molabel-btn-yes';
-  
-  const noBtn = document.createElement('button');
-  noBtn.textContent = 'No';
-  noBtn.className = 'molabel-btn molabel-btn-no';
-  
-  const skipBtn = document.createElement('button');
-  skipBtn.textContent = 'Skip';
-  skipBtn.className = 'molabel-btn molabel-btn-skip';
-  
-  controls.appendChild(prevBtn);
-  controls.appendChild(yesBtn);
-  controls.appendChild(noBtn);
-  controls.appendChild(skipBtn);
-  
-  // Create notes field
-  const notesContainer = document.createElement('div');
-  notesContainer.className = 'molabel-notes-container';
-  
-  const notesLabelContainer = document.createElement('div');
-  notesLabelContainer.className = 'molabel-notes-label-container';
-  
-  const notesLabel = document.createElement('label');
-  notesLabel.textContent = 'Notes:';
-  
-  const micButton = document.createElement('button');
-  micButton.className = 'molabel-mic-btn';
-  micButton.innerHTML = '🎤';
-  micButton.title = 'Click to record speech or hold Alt+6';
-  micButton.type = 'button';
-  
-  const gamepadIndicator = document.createElement('span');
-  gamepadIndicator.className = 'molabel-gamepad-indicator';
-  gamepadIndicator.innerHTML = '🎮';
-  gamepadIndicator.style.display = 'none';
-  gamepadIndicator.title = 'Gamepad detected';
-  
-  const buttonContainer = document.createElement('div');
-  buttonContainer.className = 'molabel-button-container';
-  buttonContainer.appendChild(gamepadIndicator);
-  buttonContainer.appendChild(micButton);
-  
-  notesLabelContainer.appendChild(notesLabel);
-  notesLabelContainer.appendChild(buttonContainer);
-  
-  const notesField = document.createElement('textarea');
-  notesField.className = 'molabel-notes';
-  notesField.rows = 3;
-  notesField.placeholder = 'Add any notes about this example...';
-  
-  notesContainer.appendChild(notesLabelContainer);
-  notesContainer.appendChild(notesField);
-  
-  // Create progress bar
-  const progressContainer = document.createElement('div');
-  progressContainer.className = 'molabel-progress-container';
-  const progressBar = document.createElement('div');
-  progressBar.className = 'molabel-progress-bar';
-  const progressFill = document.createElement('div');
-  progressFill.className = 'molabel-progress-fill';
-  progressBar.appendChild(progressFill);
-  progressContainer.appendChild(progressBar);
-  
-  // Create shortcuts display
-  const shortcutsInfo = document.createElement('div');
-  shortcutsInfo.className = 'molabel-shortcuts';
-  
-  // Gamepad indicator is now part of notes label container
-  
-  // Gamepad state variables (declare early)
-  let gamepadConnected = false;
-  let lastGamepadEvent = '';
-  let gamepadIndex = -1;
-  let currentlyPressedButtons = new Set(); // Track all currently pressed buttons
-  
-  // Speech recognition variables
-  let speechRecognition = null;
-  let speechAvailable = false;
-  let isRecording = false;
-  let speechGamepadPressed = false;
-  let originalNotesText = ''; // Store original text before speech session
-  
-  
-  // Assemble the widget
-  container.appendChild(header);
-  container.appendChild(progressContainer);
-  container.appendChild(exampleContainer);
-  container.appendChild(controls);
-  container.appendChild(notesContainer);
-  container.appendChild(shortcutsInfo);
-  el.appendChild(container);
-  
-  // Helper function to render examples
-  function renderExample(example) {
-    // Default rendering
-    if (typeof example === 'object') {
-      return JSON.stringify(example, null, 2);
-    }
-    return String(example);
-  }
-  
-  // Update display function
-  function updateDisplay() {
-    console.log('🔄 updateDisplay called');
-    const examples = model.get('examples');
-    const currentIndex = model.get('current_index');
-    const showNotes = model.get('notes');
-    const shortcuts = model.get('shortcuts');
-    
-    // Update status
-    status.textContent = `Example ${currentIndex + 1} of ${examples.length}`;
-    
-    // Update example display
-    if (examples.length > 0 && currentIndex < examples.length) {
-      const currentExample = examples[currentIndex];
-      // Use _html key if available, otherwise use default rendering
-      if (currentExample._html) {
-        exampleContainer.innerHTML = currentExample._html;
-      } else {
-        const rendered = renderExample(currentExample);
-        exampleContainer.textContent = rendered;
-      }
-    } else {
-      exampleContainer.textContent = 'No examples to display';
-    }
-    
-    // Update notes field with existing annotation if available
-    const annotations = model.get('annotations');
-    const existingAnnotation = annotations.find(ann => ann.index === currentIndex);
-    const newNotesValue = existingAnnotation ? existingAnnotation._notes || '' : '';
-    
-    // Only update notes field if we're not currently recording speech
-    if (!isRecording) {
-      notesField.value = newNotesValue;
-      console.log('📝 updateDisplay set notes field to:', newNotesValue);
-    } else {
-      console.log('🚫 updateDisplay skipped notes update because currently recording speech');
-    }
-    
-    // Show/hide notes
-    notesContainer.style.display = showNotes ? 'block' : 'none';
-    
-    // Update progress bar based on current position
-    const progress = examples.length > 0 ? (currentIndex / examples.length) * 100 : 0;
-    progressFill.style.width = `${progress}%`;
-    
-    // Shortcuts display with table
-    const gamepadShortcuts = model.get('gamepad_shortcuts');
-    const hasShortcuts = (shortcuts && Object.keys(shortcuts).length > 0) || 
-                        (gamepadShortcuts && Object.keys(gamepadShortcuts).length > 0);
-    
-    let shortcutsText = '';
-    if (hasShortcuts) {
-      shortcutsText = `
-        <details class="shortcuts-details">
-          <summary>Shortcuts</summary>
-          <table class="shortcuts-table">
-            <thead>
-              <tr>
-                <th>Action</th>
-                <th>Keyboard</th>
-                <th>Gamepad</th>
-              </tr>
-            </thead>
-            <tbody>`;
-      
-      // Create unified action list
-      const allActions = new Set();
-      Object.values(shortcuts).forEach(action => allActions.add(action));
-      Object.values(gamepadShortcuts || {}).forEach(action => allActions.add(action));
-      
-      const actionOrder = ['prev', 'yes', 'no', 'skip', 'focus_notes', 'speech_notes'];
-      const sortedActions = actionOrder.filter(action => allActions.has(action));
-      
-      sortedActions.forEach(action => {
-        const keyboardKey = Object.keys(shortcuts).find(key => shortcuts[key] === action) || '';
-        const gamepadKey = Object.keys(gamepadShortcuts || {}).find(key => gamepadShortcuts[key] === action) || '';
-        
-        shortcutsText += `
-          <tr>
-            <td class="action-name">${action}</td>
-            <td>${keyboardKey ? `<span class="shortcut-key">${keyboardKey}</span>` : '-'}</td>
-            <td>${gamepadKey ? `<span class="shortcut-key">${gamepadKey}</span>` : '-'}</td>
-          </tr>`;
-      });
-      
-      shortcutsText += `
-            </tbody>
-          </table>
-        </details>`;
-    }
-    
-    shortcutsInfo.innerHTML = shortcutsText;
-    
-    // Disable/enable buttons
-    prevBtn.disabled = currentIndex === 0;
-    // Check if we're at the last example
-    const isLastExample = currentIndex >= examples.length - 1;
-    const noMoreExamples = currentIndex >= examples.length;
-    
-    // Only disable action buttons if we've gone past all examples
-    yesBtn.disabled = noMoreExamples;
-    noBtn.disabled = noMoreExamples;
-    skipBtn.disabled = noMoreExamples;
-    
-    if (isLastExample && currentIndex < examples.length) {
-      // We're on the last example but haven't annotated it yet
-      status.textContent = `Example ${currentIndex + 1} of ${examples.length} (Last example)`;
-    } else if (noMoreExamples) {
-      status.textContent = 'All examples annotated!';
-    }
-  }
-  
-  // Annotation function
-  function annotate(label) {
-    const examples = model.get('examples');
-    const currentIndex = model.get('current_index');
-    const annotations = model.get('annotations');
-    const showNotes = model.get('notes');
-    
-    if (currentIndex >= examples.length) return;
-    
-    const annotation = {
-      index: currentIndex,
-      example: examples[currentIndex],
-      _label: label,
-      _notes: showNotes ? notesField.value : '',
-      _timestamp: new Date().toISOString()
-    };
-    
-    // Add visual feedback to buttons
-    const feedbackClass = label === 'yes' ? 'success-feedback' : 
-                         label === 'no' ? 'error-feedback' : 
-                         'skip-feedback';
-    
-    const button = label === 'yes' ? yesBtn : 
-                  label === 'no' ? noBtn : 
-                  skipBtn;
-                  
-    button.classList.add(feedbackClass);
-    
-    // Remove feedback class after animation
-    setTimeout(() => {
-      button.classList.remove(feedbackClass);
-    }, 300);
-    
-    // Replace existing annotation for this index or add new one
-    const newAnnotations = annotations.filter(ann => ann.index !== currentIndex);
-    newAnnotations.push(annotation);
-    model.set('annotations', newAnnotations);
-    
-    // Move to next example (even if it's past the end)
-    model.set('current_index', currentIndex + 1);
-    model.save_changes();
-  }
-  
-  // Navigation function
-  function navigate(direction) {
-    const currentIndex = model.get('current_index');
-    if (direction === 'prev' && currentIndex > 0) {
-      // Add visual feedback to previous button
-      prevBtn.classList.add('prev-feedback');
-      
-      // Remove feedback class after animation
-      setTimeout(() => {
-        prevBtn.classList.remove('prev-feedback');
-      }, 300);
-      
-      model.set('current_index', currentIndex - 1);
-      model.save_changes();
-    }
-  }
-  
-  // Button event listeners
-  prevBtn.addEventListener('click', () => navigate('prev'));
-  yesBtn.addEventListener('click', () => annotate('yes'));
-  noBtn.addEventListener('click', () => annotate('no'));
-  skipBtn.addEventListener('click', () => annotate('skip'));
-  
-  // Microphone button event listener
-  micButton.addEventListener('click', () => {
-    console.log('🎤 Microphone button clicked - isRecording:', isRecording);
-    if (isRecording) {
-      console.log('🎤 Button click stopping recording');
-      stopSpeechRecognition();
-    } else {
-      console.log('🎤 Button click starting recording');
-      startSpeechRecognition();
-    }
-  });
-  
-  
-  // Helper function to parse keyboard shortcuts with modifiers
-  function parseShortcut(event) {
-    const modifiers = [];
-    if (event.ctrlKey) modifiers.push('Ctrl');
-    if (event.altKey) modifiers.push('Alt');
-    if (event.shiftKey) modifiers.push('Shift');
-    if (event.metaKey) modifiers.push('Meta');
-    
-    // Use event.code for consistent key identification
-    let key = event.code;
-    
-    // Filter out modifier keys themselves
-    const modifierCodes = ['ControlLeft', 'ControlRight', 'AltLeft', 'AltRight', 
-                          'ShiftLeft', 'ShiftRight', 'MetaLeft', 'MetaRight'];
-    if (modifierCodes.includes(key)) {
-      return ''; // Don't capture just modifier keys
-    }
-    
-    // Clean up the key code to make it more readable
-    key = key.replace('Key', '').replace('Digit', ''); // KeyA → A, Digit1 → 1
-    
-    return modifiers.length > 0 ? `${modifiers.join('+')}+${key}` : key;
-  }
-  
-  // Helper function to handle shortcut actions
-  function handleAction(action) {
-    switch(action) {
-      case 'prev':
-        navigate('prev');
-        break;
-      case 'yes':
-        annotate('yes');
-        break;
-      case 'no':
-        annotate('no');
-        break;
-      case 'skip':
-        annotate('skip');
-        break;
-      case 'focus_notes':
-        notesField.focus();
-        break;
-      case 'speech_notes':
-        if (isRecording) {
-          stopSpeechRecognition();
-        } else {
-          startSpeechRecognition();
-        }
-        break;
-    }
-  }
-  
-  // Keyboard shortcuts - attach to container instead of document
-  container.addEventListener('keydown', (e) => {
-    const shortcuts = model.get('shortcuts');
-    const shortcutString = parseShortcut(e);
-    
-    console.log('🎹 Keydown event - shortcut:', shortcutString);
-    
-    // Handle speech toggle (same as mouse click)
-    if (shortcuts[shortcutString] === 'speech_notes') {
-      console.log('🎹 Keyboard speech key pressed - toggling recording');
-      e.preventDefault();
-      e.stopPropagation();
-      handleAction('speech_notes');
-      return;
-    }
-    
-    if (shortcuts[shortcutString]) {
-      // console.log('Executing action:', shortcuts[shortcutString]);
-      e.preventDefault();
-      e.stopPropagation();
-      handleAction(shortcuts[shortcutString]);
-    }
-  });
-  
-  // No keyup listener needed - keyboard shortcut now works as toggle
-  
-  // Click handler removed to prevent autofocus in Marimo
-  
-  // Listen for model changes
-  model.on('change:current_index', updateDisplay);
-  model.on('change:examples', updateDisplay);
-  model.on('change:notes', updateDisplay);
-  model.on('change:shortcuts', updateDisplay);
-  model.on('change:gamepad_shortcuts', updateDisplay);
-  
-  // Initialize speech recognition
-  function initSpeechRecognition() {
-    console.log('🔧 Initializing speech recognition...');
-    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
-    
-    if (SpeechRecognition) {
-      console.log('✅ Speech Recognition API found');
-      speechRecognition = new SpeechRecognition();
-      speechRecognition.continuous = true;
-      speechRecognition.interimResults = true;
-      speechRecognition.lang = 'en-US';
-      
-      speechRecognition.onstart = () => {
-        console.log('🎤 Speech recognition started');
-        isRecording = true;
-        originalNotesText = notesField.value; // Store original text
-        console.log('📝 Original notes text stored:', originalNotesText);
-        updateRecordingUI();
-      };
-      
-      speechRecognition.onresult = (event) => {
-        console.log('📢 Speech result event - resultIndex:', event.resultIndex, 'total results:', event.results.length);
-        let newFinalTranscript = '';
-        let newInterimTranscript = '';
-        
-        // Only process NEW results from resultIndex onwards (prevents duplication)
-        for (let i = event.resultIndex; i < event.results.length; i++) {
-          const transcript = event.results[i][0].transcript;
-          const isFinal = event.results[i].isFinal;
-          console.log(`  Result ${i}: "${transcript}" (final: ${isFinal})`);
-          
-          if (isFinal) {
-            newFinalTranscript += transcript;
-          } else {
-            newInterimTranscript += transcript;
-          }
-        }
-        
-        console.log('✅ New final transcript:', newFinalTranscript);
-        console.log('⏳ New interim transcript:', newInterimTranscript);
-        
-        // Add any new final text to our stored text
-        if (newFinalTranscript) {
-          const oldStoredText = originalNotesText;
-          const separator = originalNotesText ? ' ' : '';
-          originalNotesText = originalNotesText + separator + newFinalTranscript;
-          console.log('💾 Updated stored text from:', oldStoredText, 'to:', originalNotesText);
-        }
-        
-        // Show live results: stored final text + current interim text
-        if (newInterimTranscript) {
-          const separator = originalNotesText ? ' ' : '';
-          const displayText = originalNotesText + separator + newInterimTranscript;
-          console.log('👁️ Showing live text:', displayText);
-          notesField.value = displayText;
-          console.log('🔍 After setting value, notesField.value is now:', notesField.value);
-        } else {
-          // No interim text, just show the stored final text
-          console.log('📋 Showing final text only:', originalNotesText);
-          notesField.value = originalNotesText;
-          console.log('🔍 After setting final value, notesField.value is now:', notesField.value);
-        }
-      };
-      
-      speechRecognition.onend = () => {
-        console.log('🛑 Speech recognition ended. Final stored text:', originalNotesText);
-        isRecording = false;
-        
-        // Ensure final text is preserved
-        notesField.value = originalNotesText;
-        console.log('📝 Set notes field to final text on end');
-        updateRecordingUI();
-      };
-      
-      speechRecognition.onerror = (event) => {
-        console.log('❌ Speech recognition error:', event.error);
-        isRecording = false;
-        
-        // Preserve text even on error
-        notesField.value = originalNotesText;
-        console.log('📝 Set notes field to stored text on error');
-        updateRecordingUI();
-      };
-      
-      speechAvailable = true;
-      console.log('🎉 Speech recognition fully initialized and available');
-    } else {
-      console.log('❌ Speech recognition not available in this browser');
-      speechAvailable = false;
-    }
-    
-    updateMicButtonState();
-  }
-  
-  function updateRecordingUI() {
-    if (isRecording) {
-      micButton.classList.add('recording');
-      notesField.classList.add('recording');
-      micButton.innerHTML = '🔴';
-      micButton.title = 'Recording... (release to stop)';
-    } else {
-      micButton.classList.remove('recording');
-      notesField.classList.remove('recording');
-      micButton.innerHTML = speechAvailable ? '🎤' : '❌';
-      micButton.title = speechAvailable ? 'Click to record speech or hold Alt+6' : 'Speech recognition not available';
-    }
-  }
-  
-  function updateMicButtonState() {
-    micButton.disabled = !speechAvailable;
-    updateRecordingUI();
-  }
-  
-  function startSpeechRecognition() {
-    console.log('🚀 startSpeechRecognition called - speechAvailable:', speechAvailable, 'isRecording:', isRecording);
-    if (speechAvailable && !isRecording) {
-      try {
-        console.log('▶️ Calling speechRecognition.start()');
-        speechRecognition.start();
-      } catch (error) {
-        console.log('💥 Error starting speech recognition:', error);
-      }
-    } else {
-      console.log('⚠️ Cannot start - speechAvailable:', speechAvailable, 'isRecording:', isRecording);
-    }
-  }
-  
-  function stopSpeechRecognition() {
-    console.log('🛑 stopSpeechRecognition called - speechAvailable:', speechAvailable, 'isRecording:', isRecording);
-    if (speechAvailable && isRecording) {
-      try {
-        console.log('⏹️ Calling speechRecognition.stop()');
-        speechRecognition.stop();
-      } catch (error) {
-        console.log('💥 Error stopping speech recognition:', error);
-      }
-    } else {
-      console.log('⚠️ Cannot stop - speechAvailable:', speechAvailable, 'isRecording:', isRecording);
-    }
-  }
-  
-  // Initialize speech recognition
-  initSpeechRecognition();
-  
-  // Initial display
-  updateDisplay();
-  
-  // No autofocus to prevent jumping in Marimo notebooks
-  
-  // Gamepad support (variables already declared above)
-  
-  // Gamepad display now handled by simple indicator emoji
-  
-  // Gamepad connection events
-  window.addEventListener('gamepadconnected', (e) => {
-    console.log('Gamepad connected:', e.gamepad);
-    gamepadConnected = true;
-    gamepadIndex = e.gamepad.index;
-    lastGamepadEvent = 'Connected';
-    gamepadIndicator.style.display = 'inline';
-  });
-  
-  window.addEventListener('gamepaddisconnected', (e) => {
-    console.log('Gamepad disconnected:', e.gamepad);
-    gamepadConnected = false;
-    gamepadIndex = -1;
-    lastGamepadEvent = 'Disconnected';
+function render({
+    model,
+    el
+}) {
+
+
+    /* -----------------------
+
+          LAYOUT & ELEMENTS
+
+    -------------------------- */
+
+    // HEADER & EXAMPLES
+    // Header
+    const header = document.createElement('div');
+    header.className = 'molabel-header';
+    const status = document.createElement('div');
+    status.className = 'molabel-status';
+    header.appendChild(status);
+
+    // Example display
+    const exampleContainer = document.createElement('div');
+    exampleContainer.className = 'molabel-example';
+
+    // Last choice (for speech commands)
+    const lastChoiceDisplay = document.createElement('div');
+    lastChoiceDisplay.className = 'molabel-last-choice';
+
+    // NAVIGATION CONTROLS
+    const controls = document.createElement('div');
+    controls.className = 'molabel-controls';
+    const prevBtn = document.createElement('button');
+    prevBtn.textContent = 'Previous';
+    prevBtn.className = 'molabel-btn molabel-btn-prev';
+    const yesBtn = document.createElement('button');
+    yesBtn.textContent = 'Yes';
+    yesBtn.className = 'molabel-btn molabel-btn-yes';
+    const noBtn = document.createElement('button');
+    noBtn.textContent = 'No';
+    noBtn.className = 'molabel-btn molabel-btn-no';
+    const skipBtn = document.createElement('button');
+    skipBtn.textContent = 'Skip';
+    skipBtn.className = 'molabel-btn molabel-btn-skip';
+    controls.appendChild(prevBtn);
+    controls.appendChild(yesBtn);
+    controls.appendChild(noBtn);
+    controls.appendChild(skipBtn);
+
+    // INPUT SELECTION & NOTES
+    // Note recording
+    const micButton = document.createElement('button');
+    micButton.className = 'molabel-mic-btn';
+    micButton.innerHTML = '🎤';
+    micButton.title = 'Record a note';
+    micButton.type = 'button';
+
+    // Speech-based commands
+    const speechSelectionBtn = document.createElement('button');
+    speechSelectionBtn.className = 'molabel-speech-select-btn';
+    speechSelectionBtn.innerHTML = '🗣️';
+    speechSelectionBtn.title = 'Activate Speech command mode';
+    speechSelectionBtn.type = 'button';
+
+    // Gamepad indicator
+    const gamepadIndicator = document.createElement('span');
+    gamepadIndicator.className = 'molabel-gamepad-indicator';
+    gamepadIndicator.innerHTML = '🎮';
     gamepadIndicator.style.display = 'none';
-  });
-  
-  // Gamepad polling for button presses
-  let lastButtonStates = {};
-  
-  function pollGamepad() {
-    if (!gamepadConnected) {
-      requestAnimationFrame(pollGamepad);
-      return;
-    }
-    
-    const gamepads = navigator.getGamepads();
-    const gamepad = gamepads[gamepadIndex];
-    
-    if (gamepad) {
-      // Check for button presses
-      gamepad.buttons.forEach((button, index) => {
-        const buttonKey = `button_${index}`;
-        const wasPressed = lastButtonStates[buttonKey] || false;
-        const isPressed = button.pressed;
-        
-        // Update currently pressed buttons set
-        if (isPressed) {
-          currentlyPressedButtons.add(index);
-        } else {
-          currentlyPressedButtons.delete(index);
-        }
-        
-        // Detect button press (transition from not pressed to pressed)
-        if (isPressed && !wasPressed) {
-          lastGamepadEvent = `Button ${index} pressed`;
-          gamepadIndicator.style.display = 'inline'; // Show indicator on any button press
-          // console.log(`Gamepad button ${index} pressed`);
-          
-          // Check for mapped gamepad actions
-          const gamepadShortcuts = model.get('gamepad_shortcuts');
-          if (gamepadShortcuts[buttonKey]) {
-            // Handle speech push-to-talk
-            if (gamepadShortcuts[buttonKey] === 'speech_notes') {
-              console.log('🎮 Gamepad speech button pressed - starting recording');
-              speechGamepadPressed = true;
-              startSpeechRecognition();
-            } else {
-              // console.log(`Executing gamepad action: ${gamepadShortcuts[buttonKey]}`);
-              handleAction(gamepadShortcuts[buttonKey]);
+    gamepadIndicator.title = 'Gamepad detected';
+
+    const helpBtn = document.createElement('button');
+    helpBtn.className = 'molabel-help-btn';
+    helpBtn.innerHTML = '❓';
+    helpBtn.title = 'Show shortcuts (Alt+i)';
+    const buttonContainer = document.createElement('div');
+    buttonContainer.className = 'molabel-button-container';
+    buttonContainer.appendChild(gamepadIndicator);
+    buttonContainer.appendChild(speechSelectionBtn);
+    buttonContainer.appendChild(micButton);
+    buttonContainer.appendChild(helpBtn);
+
+    // Notes
+    const notesLabel = document.createElement('label');
+    notesLabel.textContent = 'Notes:';
+    const notesField = document.createElement('textarea');
+    notesField.className = 'molabel-notes';
+    notesField.rows = 3;
+    notesField.placeholder = 'Add any notes about this example...';
+
+    // Add notes, label, input selection to container
+    const notesContainer = document.createElement('div');
+    notesContainer.className = 'molabel-notes-container';
+
+    const notesLabelContainer = document.createElement('div');
+    notesLabelContainer.className = 'molabel-notes-label-container';
+
+    notesLabelContainer.appendChild(notesLabel);
+    notesLabelContainer.appendChild(buttonContainer);
+
+    notesContainer.appendChild(notesLabelContainer);
+    notesContainer.appendChild(notesField);
+
+    // progress bar
+    const progressContainer = document.createElement('div');
+    progressContainer.className = 'molabel-progress-container';
+    const progressBar = document.createElement('div');
+    progressBar.className = 'molabel-progress-bar';
+    const progressFill = document.createElement('div');
+    progressFill.className = 'molabel-progress-fill';
+    progressBar.appendChild(progressFill);
+    progressContainer.appendChild(progressBar);
+
+    // Help overlay
+    const helpOverlay = document.createElement('div');
+    helpOverlay.className = 'molabel-help-overlay';
+    const helpContent = document.createElement('div');
+    helpContent.className = 'molabel-help-content';
+    helpOverlay.appendChild(helpContent);
+
+    // Set up main container
+    const container = document.createElement('div');
+    container.className = 'molabel-container';
+    container.tabIndex = 0;
+
+    container.appendChild(header);
+    container.appendChild(progressContainer);
+    container.appendChild(exampleContainer);
+    container.appendChild(lastChoiceDisplay);
+    container.appendChild(controls);
+    container.appendChild(notesContainer);
+    container.appendChild(helpOverlay);
+
+    el.appendChild(container);
+
+
+
+    /* --------------------------
+
+            STATE VARIABLES
+
+      -------------------------- */
+    // Gamepad
+    let gamepadConnected = false;
+    let gamepadIndex = -1;
+    let lastButtonStates = {};
+
+    // Speech recognition
+    let speechRecognition = null;
+    let speechAvailable = false;
+    let isRecording = false;
+    let speechGamepadPressed = false;
+    let originalNotesText = '';
+
+    // Speech selection
+    let isSpeechSelectionMode = false;
+    let speechSelectionToggledOn = false;
+    let speechSelectionHotkeyDown = false;
+    let isHelpVisible = false;
+
+    /* --------------------------
+
+              CONSTANTS
+
+      -------------------------- */
+
+    // Gamepad
+
+    const GAMEPAD_NAMES = {
+      // TODO:
+      // - [ ] Verify if button mapping is correct
+      // - [ ] Add additional buttons: menu, share, ...
+
+        'button_0': {
+            text: 'A',
+            className: 'gamepad-btn gamepad-btn-round',
+            style: {
+                color: '#a3e82d',
+                textShadow: '0 0 8px #1a2a02'
             }
-          }
+        },
+        'button_1': {
+            text: 'B',
+            className: 'gamepad-btn gamepad-btn-round',
+            style: {
+                color: '#ff4d4d',
+                textShadow: '0 0 8px #4d0000'
+            }
+        },
+        'button_2': {
+            text: 'X',
+            className: 'gamepad-btn gamepad-btn-round',
+            style: {
+                color: '#55b4ff',
+                textShadow: '0 0 8px #002a4d'
+            }
+        },
+        'button_3': {
+            text: 'Y',
+            className: 'gamepad-btn gamepad-btn-round',
+            style: {
+                color: '#ffde55',
+                textShadow: '0 0 8px #4d3c00'
+            }
+        },
+        'button_4': {
+            text: 'LB',
+            className: 'gamepad-btn gamepad-btn-rect'
+        },
+        'button_5': {
+            text: 'RB',
+            className: 'gamepad-btn gamepad-btn-rect'
+        },
+        'button_6': {
+            text: 'LT',
+            className: 'gamepad-btn gamepad-btn-trigger'
+        },
+        'button_7': {
+            text: 'RT',
+            className: 'gamepad-btn gamepad-btn-trigger'
+        },
+        'button_8': {
+            className: 'gamepad-btn gamepad-btn-round',
+            style: {
+                color: 'white'
+            },
+            html: `<svg class="gamepad-view-icon" viewBox="0 0 70 70" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><g transform="translate(0,-1052.5)"><circle cx="35" cy="1087.5" r="32.5"/><rect x="31.25" y="1085" width="20" height="15"/><path d="m38.75 1077.5v-5h-20v15h5"/></g></svg>`
+        },
+    };
+
+
+    const gamepad = navigator.getGamepads()[gamepadIndex];
+
+
+
+    /* -----------------------
+
+          EVENT LISTENERS
+
+    ------------------------- */
+
+    // Navigation
+    prevBtn.addEventListener('click', () => navigate('prev'));
+    yesBtn.addEventListener('click', () => annotate('yes'));
+    noBtn.addEventListener('click', () => annotate('no'));
+    skipBtn.addEventListener('click', () => annotate('skip'));
+
+    // Input select buttons
+    micButton.addEventListener('click', () => {
+        if (isRecording) stopSpeechRecognition();
+        else startSpeechRecognition();
+    });
+
+    speechSelectionBtn.addEventListener('click', () => {
+        speechSelectionToggledOn = !speechSelectionToggledOn;
+        if (speechSelectionToggledOn) {
+            startSpeechSelectionMode();
+        } else {
+            stopSpeechSelectionMode();
         }
-        
-        // Detect button release (transition from pressed to not pressed)
-        if (!isPressed && wasPressed) {
-          // Check for speech push-to-talk release
-          const gamepadShortcuts = model.get('gamepad_shortcuts');
-          if (gamepadShortcuts[buttonKey] === 'speech_notes' && speechGamepadPressed) {
-            console.log('🎮 Gamepad speech button released - stopping recording');
-            speechGamepadPressed = false;
-            stopSpeechRecognition();
-          }
+    });
+
+    container.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && isHelpVisible) {
+            e.preventDefault();
+            e.stopPropagation();
+            toggleHelpOverlay();
+            return;
         }
-        
-        lastButtonStates[buttonKey] = isPressed;
-      });
-      
-      // Check for axis movements (significant changes)
-      gamepad.axes.forEach((axis, index) => {
-        const axisKey = `axis_${index}`;
-        const lastValue = lastButtonStates[axisKey] || 0;
-        const currentValue = axis;
-        
-        // Detect significant axis movement (threshold of 0.5)
-        if (Math.abs(currentValue - lastValue) > 0.1) {
-          lastGamepadEvent = `Axis ${index}: ${currentValue.toFixed(2)}`;
-          gamepadIndicator.style.display = 'inline'; // Show indicator on axis movement
-          // console.log(`Gamepad axis ${index} moved to ${currentValue.toFixed(2)}`);
+
+        const shortcutString = parseShortcut(e);
+
+        if (shortcutString.toLowerCase() === 'alt+i') {
+            e.preventDefault();
+            e.stopPropagation();
+            toggleHelpOverlay();
+            return;
         }
-        
-        lastButtonStates[axisKey] = currentValue;
-      });
-      
-      // No need to update display here - gamepad actions handle their own updates
+
+        const shortcuts = model.get('shortcuts');
+        const action = shortcuts[shortcutString];
+
+        if (action === 'speech_selection') {
+            e.preventDefault();
+            e.stopPropagation();
+            if (speechSelectionToggledOn) {
+                speechSelectionToggledOn = false;
+                stopSpeechSelectionMode();
+            } else if (!isSpeechSelectionMode) {
+                speechSelectionHotkeyDown = true;
+                startSpeechSelectionMode();
+            }
+            return;
+        }
+
+        if (action) {
+            e.preventDefault();
+            e.stopPropagation();
+            handleAction(action);
+        }
+    });
+
+    // Keyboard shortcuts
+    container.addEventListener('keyup', (e) => {
+        const shortcuts = model.get('shortcuts');
+        const shortcutString = parseShortcut(e);
+        const action = shortcuts[shortcutString];
+
+        if (action === 'speech_selection' && speechSelectionHotkeyDown) {
+            e.preventDefault();
+            e.stopPropagation();
+            speechSelectionHotkeyDown = false;
+            stopSpeechSelectionMode();
+        }
+    });
+
+    helpBtn.addEventListener('click', () => handleAction('help_overlay'));
+    helpOverlay.addEventListener('click', (e) => {
+        if (e.target === helpOverlay) {
+            toggleHelpOverlay();
+        }
+    });
+
+    //.Gamepad detection
+    window.addEventListener('gamepadconnected', (e) => {
+        gamepadConnected = true;
+        gamepadIndex = e.gamepad.index;
+        gamepadIndicator.style.display = 'inline';
+    });
+
+    window.addEventListener('gamepaddisconnected', (e) => {
+        gamepadConnected = false;
+        gamepadIndex = -1;
+        gamepadIndicator.style.display = 'none';
+    });
+
+
+
+
+    /* ------------------------------------------------
+
+                          FUNCTIONS
+
+    -------------------------------------------------- */
+
+    // --------------
+    // Initialization
+    // --------------
+    initSpeechRecognition();
+    updateDisplay();
+
+    model.on('change:current_index', updateDisplay);
+    model.on('change:examples', updateDisplay);
+    model.on('change:notes', updateDisplay);
+    model.on('change:shortcuts', updateDisplay);
+    model.on('change:gamepad_shortcuts', updateDisplay);
+
+    pollGamepad();
+
+    const existingGamepads = navigator.getGamepads();
+    for (let i = 0; i < existingGamepads.length; i++) {
+        if (existingGamepads[i]) {
+            gamepadConnected = true;
+            gamepadIndex = i;
+            gamepadIndicator.style.display = 'inline';
+            break;
+        }
     }
-    
-    // Continue polling
-    requestAnimationFrame(pollGamepad);
-  }
-  
-  // Start gamepad polling
-  pollGamepad();
-  
-  // Also check for gamepads that might already be connected
-  const existingGamepads = navigator.getGamepads();
-  for (let i = 0; i < existingGamepads.length; i++) {
-    if (existingGamepads[i]) {
-      console.log('Found existing gamepad:', existingGamepads[i]);
-      gamepadConnected = true;
-      gamepadIndex = i;
-      lastGamepadEvent = 'Connected';
-      gamepadIndicator.style.display = 'inline';
-      break;
+
+    // ---------------------------
+    // Rendering, display, actions
+    // ---------------------------
+    function renderExample(example) {
+        if (typeof example === 'object') {
+            return JSON.stringify(example, null, 2);
+        }
+        return String(example);
     }
-  }
+
+    function updateDisplay() {
+        const examples = model.get('examples');
+        const currentIndex = model.get('current_index');
+        const showNotes = model.get('notes');
+
+        status.textContent = `Example ${currentIndex + 1} of ${examples.length}`;
+
+        if (examples.length > 0 && currentIndex < examples.length) {
+            const currentExample = examples[currentIndex];
+            if (currentExample._html) {
+                exampleContainer.innerHTML = currentExample._html;
+            } else {
+                exampleContainer.textContent = renderExample(currentExample);
+            }
+        } else {
+            exampleContainer.textContent = 'No examples to display';
+        }
+
+        const annotations = model.get('annotations');
+        const existingAnnotation = annotations.find(ann => ann.index === currentIndex);
+        const newNotesValue = existingAnnotation ? existingAnnotation._notes || '' : '';
+
+        if (!isRecording) {
+            notesField.value = newNotesValue;
+        }
+
+        notesContainer.style.display = showNotes ? 'block' : 'none';
+
+        const progress = examples.length > 0 ? (currentIndex / examples.length) * 100 : 0;
+        progressFill.style.width = `${progress}%`;
+
+        prevBtn.disabled = currentIndex === 0;
+        const noMoreExamples = currentIndex >= examples.length;
+
+        yesBtn.disabled = noMoreExamples;
+        noBtn.disabled = noMoreExamples;
+        skipBtn.disabled = noMoreExamples;
+
+        if (currentIndex >= examples.length - 1 && currentIndex < examples.length) {
+            status.textContent = `Example ${currentIndex + 1} of ${examples.length} (Last example)`;
+        } else if (noMoreExamples) {
+            status.textContent = 'All examples annotated!';
+        }
+    }
+    function handleAction(action) {
+        switch (action) {
+            case 'prev':
+                navigate('prev');
+                break;
+            case 'yes':
+                annotate('yes');
+                break;
+            case 'no':
+                annotate('no');
+                break;
+            case 'skip':
+                annotate('skip');
+                break;
+            case 'focus_notes':
+                notesField.focus();
+                break;
+            case 'speech_notes':
+                if (isSpeechSelectionMode) return;
+                if (isRecording) stopSpeechRecognition();
+                else startSpeechRecognition();
+                break;
+            case 'help_overlay':
+                toggleHelpOverlay();
+                break;
+        }
+    }
+
+    // ----------
+    // Annotation
+    // ----------
+    function annotate(label) {
+        const examples = model.get('examples');
+        const currentIndex = model.get('current_index');
+        const annotations = model.get('annotations');
+        const showNotes = model.get('notes');
+
+        if (currentIndex >= examples.length) return;
+
+        const annotation = {
+            index: currentIndex,
+            example: examples[currentIndex],
+            _label: label,
+            _notes: showNotes ? notesField.value : '',
+            _timestamp: new Date().toISOString()
+        };
+
+        const feedbackClass = label === 'yes' ? 'success-feedback' : label === 'no' ? 'error-feedback' : 'skip-feedback';
+        const button = label === 'yes' ? yesBtn : label === 'no' ? noBtn : skipBtn;
+        button.classList.add(feedbackClass);
+        setTimeout(() => {
+            button.classList.remove(feedbackClass);
+        }, 300);
+
+        const newAnnotations = annotations.filter(ann => ann.index !== currentIndex);
+        newAnnotations.push(annotation);
+        model.set('annotations', newAnnotations);
+
+        model.set('current_index', currentIndex + 1);
+        model.save_changes();
+    }
+
+    function navigate(direction) {
+        const currentIndex = model.get('current_index');
+        if (direction === 'prev' && currentIndex > 0) {
+            prevBtn.classList.add('prev-feedback');
+            setTimeout(() => {
+                prevBtn.classList.remove('prev-feedback');
+            }, 300);
+            model.set('current_index', currentIndex - 1);
+            model.save_changes();
+        }
+    }
+
+    // ------------------
+    // Keyboard shortcuts
+    // ------------------
+    function parseShortcut(event) {
+        const modifiers = [];
+        if (event.ctrlKey) modifiers.push('Ctrl');
+        if (event.altKey) modifiers.push('Alt');
+        if (event.shiftKey) modifiers.push('Shift');
+        if (event.metaKey) modifiers.push('Meta');
+
+        let key = event.code;
+        const modifierCodes = ['ControlLeft', 'ControlRight', 'AltLeft', 'AltRight', 'ShiftLeft', 'ShiftRight', 'MetaLeft', 'MetaRight'];
+        if (modifierCodes.includes(key)) return '';
+
+        key = key.replace('Key', '').replace('Digit', '');
+        return modifiers.length > 0 ? `${modifiers.join('+')}+${key}` : key;
+    }
+
+
+    // --------------------------
+    // Speech recording & parsing
+    // --------------------------
+    function initSpeechRecognition() {
+        const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+        if (SpeechRecognition) {
+            speechRecognition = new SpeechRecognition();
+            speechRecognition.lang = 'en-US';
+
+            speechRecognition.onresult = (event) => {
+                if (isSpeechSelectionMode) {
+                    const fullTranscript = event.results[event.results.length - 1][0].transcript.trim().toLowerCase();
+                    const command = fullTranscript.split(' ')[0];
+
+                    lastChoiceDisplay.textContent = `Heard: "${command}"`;
+                    let actionFound = true;
+                    switch (command) {
+                        case 'yes':
+                            handleAction('yes');
+                            break;
+                        case 'no':
+                            handleAction('no');
+                            break;
+                        case 'skip':
+                            handleAction('skip');
+                            break;
+                        case 'previous':
+                            handleAction('prev');
+                            break;
+                        case 'stop':
+                            if (speechSelectionToggledOn) stopSpeechSelectionMode();
+                            break;
+                        default:
+                            actionFound = false;
+                            lastChoiceDisplay.textContent += ' (not valid)';
+                            break;
+                    }
+                    if (!actionFound) {
+                        setTimeout(() => {
+                            if (lastChoiceDisplay.textContent.includes('(not valid)')) lastChoiceDisplay.textContent = '';
+                        }, 2000);
+                    }
+                } else {
+                    let newFinalTranscript = '';
+                    let newInterimTranscript = '';
+                    for (let i = event.resultIndex; i < event.results.length; i++) {
+                        const transcript = event.results[i][0].transcript;
+                        if (event.results[i].isFinal) newFinalTranscript += transcript;
+                        else newInterimTranscript += transcript;
+                    }
+                    if (newFinalTranscript) {
+                        const separator = originalNotesText ? ' ' : '';
+                        originalNotesText += separator + newFinalTranscript;
+                    }
+                    const separator = originalNotesText ? ' ' : '';
+                    notesField.value = originalNotesText + separator + newInterimTranscript;
+                }
+            };
+
+            speechRecognition.onend = () => {
+                if (isSpeechSelectionMode) {
+                    if (speechSelectionToggledOn && isSpeechSelectionMode) {
+                        try {
+                            speechRecognition.start();
+                        } catch (e) {
+                            stopSpeechSelectionMode(true);
+                        }
+                    } else if (!speechSelectionToggledOn) {
+                        stopSpeechSelectionMode();
+                    }
+                } else {
+                    isRecording = false;
+                    notesField.value = originalNotesText;
+                    updateRecordingUI();
+                }
+            };
+
+            speechRecognition.onerror = (event) => {
+                if (isSpeechSelectionMode) {
+                    lastChoiceDisplay.textContent = `Error: ${event.error}`;
+                    stopSpeechSelectionMode(true);
+                } else {
+                    console.error('Speech recognition error for notes:', event.error);
+                    isRecording = false;
+                    notesField.value = originalNotesText;
+                    updateRecordingUI();
+                }
+            };
+            speechAvailable = true;
+        } else {
+            speechAvailable = false;
+        }
+        updateMicButtonState();
+    }
+
+    function updateRecordingUI() {
+        if (isRecording) {
+            micButton.classList.add('recording');
+            notesField.classList.add('recording');
+            micButton.innerHTML = '🔴';
+        } else {
+            micButton.classList.remove('recording');
+            notesField.classList.remove('recording');
+            micButton.innerHTML = speechAvailable ? '🎤' : '❌';
+        }
+    }
+
+    function updateMicButtonState() {
+        micButton.disabled = !speechAvailable;
+        speechSelectionBtn.disabled = !speechAvailable;
+        updateRecordingUI();
+    }
+
+    function startSpeechRecognition() {
+        if (speechAvailable && !isRecording && !isSpeechSelectionMode) {
+            isRecording = true;
+            originalNotesText = notesField.value;
+            speechRecognition.continuous = true;
+            speechRecognition.interimResults = true;
+            try {
+                speechRecognition.start();
+                updateRecordingUI();
+            } catch (error) {
+                console.error("Error starting speech recognition for notes:", error);
+                isRecording = false;
+            }
+        }
+    }
+
+    function stopSpeechRecognition() {
+        if (speechAvailable && isRecording) {
+            speechRecognition.stop();
+        }
+    }
+
+    // -----------------------
+    // Speech button selection
+    // -----------------------
+    function startSpeechSelectionMode() {
+        if (isSpeechSelectionMode || !speechAvailable) return;
+        isSpeechSelectionMode = true;
+        if (isRecording) stopSpeechRecognition();
+        micButton.disabled = true;
+        container.classList.add('speech-selection-active');
+        speechSelectionBtn.classList.add('active');
+
+        const SpeechGrammarList = window.SpeechGrammarList || window.webkitSpeechGrammarList;
+        const speechRecognitionList = new SpeechGrammarList();
+        const grammar = '#JSGF V1.0; grammar commands; public <command> = yes | no | skip | previous | stop;';
+        speechRecognitionList.addFromString(grammar, 1);
+
+        speechRecognition.grammars = speechRecognitionList;
+        speechRecognition.continuous = false;
+        speechRecognition.interimResults = false;
+
+        try {
+            speechRecognition.start();
+        } catch (e) {
+            stopSpeechSelectionMode(true);
+        }
+    }
+
+    function stopSpeechSelectionMode(force = false) {
+        if (!isSpeechSelectionMode && !force) return;
+
+        isSpeechSelectionMode = false;
+        speechSelectionToggledOn = false;
+        speechSelectionHotkeyDown = false;
+
+        container.classList.remove('speech-selection-active');
+        speechSelectionBtn.classList.remove('active');
+        lastChoiceDisplay.textContent = '';
+        micButton.disabled = !speechAvailable;
+
+        if (speechRecognition) {
+            speechRecognition.stop();
+            const SpeechGrammarList = window.SpeechGrammarList || window.webkitSpeechGrammarList;
+            speechRecognition.grammars = new SpeechGrammarList();
+        }
+    }
+
+    // ------------
+    // Help overlay
+    // ------------
+
+    function toggleHelpOverlay() {
+        isHelpVisible = !isHelpVisible;
+        if (isHelpVisible) {
+            renderHelpContent();
+            helpOverlay.classList.add('is-visible');
+        } else {
+            helpOverlay.classList.remove('is-visible');
+        }
+    }
+
+    function renderHelpContent() {
+
+
+        function createGamepadBadge(buttonKey) {
+            const span = document.createElement('span');
+
+            const badgeInfo = GAMEPAD_NAMES[buttonKey] || {
+                    text: buttonKey.replace(/button_/, 'B'),
+                    className: 'molabel-key'
+                };
+            if (badgeInfo.className) {
+                span.className = badgeInfo.className;
+            }
+            if (badgeInfo.style) {
+                Object.assign(span.style, badgeInfo.style);
+            }
+            if (badgeInfo.html) {
+                span.innerHTML = badgeInfo.html;
+            } else {
+                span.textContent = badgeInfo.text;
+            }
+            return span;
+        }
+
+        function createKeyBadge(shortcutString) {
+            const container = document.createElement('span');
+            container.className = 'inline-flex items-center gap-1';
+            const keys = shortcutString.split('+');
+            keys.forEach((key, index) => {
+                const kbd = document.createElement('kbd');
+                kbd.className = 'molabel-key';
+                kbd.textContent = key;
+                container.appendChild(kbd);
+                if (index < keys.length - 1) {
+                    const separator = document.createElement('span');
+                    separator.className = 'key-separator';
+                    separator.textContent = '+';
+                    container.appendChild(separator);
+                }
+            });
+            return container;
+        }
+
+        const shortcuts = model.get('shortcuts');
+        const gamepadShortcuts = model.get('gamepad_shortcuts');
+
+        const allActions = new Set();
+        Object.values(shortcuts).forEach(action => allActions.add(action));
+        Object.values(gamepadShortcuts).forEach(action => allActions.add(action));
+
+        const actionOrder = ['prev', 'yes', 'no', 'skip', 'focus_notes', 'speech_notes', 'speech_selection'];
+        const sortedActions = actionOrder.filter(action => allActions.has(action));
+
+        const keyForAction = Object.fromEntries(Object.entries(shortcuts).map(([k, v]) => [v, k]));
+        const gamepadForAction = Object.fromEntries(Object.entries(gamepadShortcuts).map(([k, v]) => [v, k]));
+
+        helpContent.innerHTML = ''; // Clear previous content
+
+        const title = document.createElement('h2');
+        title.className = 'molabel-help-title';
+        title.textContent = 'Shortcuts';
+        helpContent.appendChild(title);
+
+        const table = document.createElement('table');
+        table.className = 'molabel-help-table';
+
+        const thead = table.createTHead();
+        const headerRow = thead.insertRow();
+        ['Action', 'Keyboard', 'Gamepad'].forEach(text => {
+            const th = document.createElement('th');
+            th.textContent = text;
+            headerRow.appendChild(th);
+        });
+
+        const tbody = table.createTBody();
+        const addRow = (action, fixedKeys) => {
+            const row = tbody.insertRow();
+            const actionCell = row.insertCell();
+            actionCell.className = 'action-name-cell';
+            actionCell.textContent = action.replace(/_/g, ' ');
+
+            const keyboardCell = row.insertCell();
+            keyboardCell.className = 'shortcut-cell';
+            const keyboardKey = fixedKeys ? fixedKeys.keyboard : keyForAction[action];
+            if (keyboardKey) {
+                keyboardCell.appendChild(createKeyBadge(keyboardKey));
+            }
+
+            const gamepadCell = row.insertCell();
+            gamepadCell.className = 'shortcut-cell';
+            const gamepadKey = fixedKeys ? fixedKeys.gamepad : gamepadForAction[action];
+            if (gamepadKey) {
+                gamepadCell.appendChild(createGamepadBadge(gamepadKey));
+            }
+        };
+        sortedActions.forEach(action => addRow(action));
+        addRow('Show / Hide Help', {
+            keyboard: 'Alt+i',
+            gamepad: 'button_8'
+        });
+        helpContent.appendChild(table);
+
+        const closeBtn = document.createElement('button');
+        closeBtn.className = 'absolute top-2 right-3 text-2xl text-gray-500 hover:text-gray-800 dark:hover:text-gray-200 transition-colors';
+        closeBtn.innerHTML = '×';
+        closeBtn.title = 'Close (Esc)';
+        closeBtn.onclick = toggleHelpOverlay;
+        helpContent.appendChild(closeBtn);
+    }
+
+    // -------
+    // Gamepad
+    // -------
+    function pollGamepad() {
+        if (!gamepadConnected) {
+            requestAnimationFrame(pollGamepad);
+            return;
+        }
+        if (gamepad) {
+            const gamepadShortcuts = model.get('gamepad_shortcuts');
+            gamepad.buttons.forEach((button, index) => {
+                const buttonKey = `button_${index}`;
+                const wasPressed = lastButtonStates[buttonKey] || false;
+                const isPressed = button.pressed;
+
+
+                if (isPressed && !wasPressed) {
+                    if (buttonKey === 'button_8') {
+                        toggleHelpOverlay();
+                    }
+
+                    gamepadIndicator.style.display = 'inline';
+                    const action = gamepadShortcuts[buttonKey];
+                    if (action) {
+                        if (action === 'speech_selection') {
+                            if (speechSelectionToggledOn) {
+                                speechSelectionToggledOn = false;
+                                stopSpeechSelectionMode();
+                            } else if (!isSpeechSelectionMode) {
+                                speechSelectionHotkeyDown = true;
+                                startSpeechSelectionMode();
+                            }
+                        } else if (action === 'speech_notes') {
+                            if (isSpeechSelectionMode) return;
+                            speechGamepadPressed = true;
+                            startSpeechRecognition();
+                        } else {
+                            handleAction(action);
+                        }
+                    }
+                }
+
+                if (!isPressed && wasPressed) {
+                    const action = gamepadShortcuts[buttonKey];
+                    if (action === 'speech_selection' && speechSelectionHotkeyDown) {
+                        speechSelectionHotkeyDown = false;
+                        stopSpeechSelectionMode();
+                    } else if (action === 'speech_notes' && speechGamepadPressed) {
+                        speechGamepadPressed = false;
+                        stopSpeechRecognition();
+                    }
+                }
+                lastButtonStates[buttonKey] = isPressed;
+            });
+        }
+        requestAnimationFrame(pollGamepad);
+    }
 }
 
-export default { render };
+export default {
+    render
+};


### PR DESCRIPTION
# Changes

### Preparation

- Removed fold-out list with hardcoded shortcuts
- Refactored `widgets.js`: included section and subsections, re-ordered and grouped functionality.
- Additionaly, I also removed quite some comments and console output from `widgets.js` to clean it up.
 
## Feat 1: Help/shortcuts overview modal

![image](https://github.com/user-attachments/assets/6d8b5555-03c5-4791-81c7-4f74b4946468)
*The new shortcut/help overview modal.*

![image](https://github.com/user-attachments/assets/4424187d-392b-4581-9e55-fdd508d727ee)
*A button to display this modal with ❓. Also visible: the 🗣️ button to activate the speech command mode, see Feat 2 below.*

- Added a modal displaying dynamically generated keyboard & gamepad shortcuts
- Added pretty rendering for keyboard + gamepad. Mostly in `widgets.css`, but part is defined in `widgets.js`
- `Alt-i`: baked-in keyboard shortcut for help
- controller `button_8`: baked-in shortcut for opening help  
- added button to display the help modal next to the mic/gamepad icons above the notes field 

## Feat 2: Speech command mode

![image](https://github.com/user-attachments/assets/23cb3efa-bb19-4ec3-b29c-ec60c40bb229)
*A screenshot showing the speech command mode in it's active state, and displaying the last recognized command*

- New mode: speech-based input, using the `SpeechRecognition.grammar` functionality to pre-define acceptable keywords, e.g. `previous`, `yes`, `no`, ...
- Added a new action, default shortcut, and UI button to activate the speech controls
- Activating the mode will display a border around the app
- Displays the latest parsed speech input when mode is active, so the user can go back and fix manually if wrong. Will also let the user know if input is not recognized:

![image](https://github.com/user-attachments/assets/fa807ea1-94e8-4b0e-9890-315482f0195b)

- When the parser detects multiple words, it will only consider the first word (split on whitespace)
- *Should* handle switching to/from speech-based notes gracefully.

# Known Issues & Future Improvements

- [ ] Gamepad button display and mapping
  - [ ] *Verify mapping*: Gamepad button to actual face button mapping is incomplete and not verified/tested/checked
  - [ ] *Finish mapping*: Various buttons are not implemented (e.g. `select`, `start`, ...)
  - [ ] *Add more styles*: Currently only includes `Xbox One`-style buttons
- [ ] Speech commands issues
  - [ ] *Stop when keyword is said*: Sometimes the function does not stop parsing (and thus does not enter a command) even though a keyword is found. It will wait for more words to be said. The current split on whitespace function handles this, but it is annoying and slows things down.
  - [ ] *Test mode activation/switching*: Not all combinations of functions have been tested to see if it's handled properly
  - [ ] *Add dynamic commands*: Commands are hardcoded in, should be easily changed to a dynamic list of keywords to pass into the grammar
- [ ] *Verify that styling works correctly*: Developed this inside `marimo`, but the quirks of marimo styling inside an anywidget instance, combined with dark and light mode, importing tailwind in the main demo for `molabel`... this might've led to some bad assumptions, strange fixes, or other mishaps. So, the final styling/display of all elements should be checked in various environments to see if everything works correctly, especially the help menu. 
- [ ] *`widgets.js` choices*: I removed quite some comments and log messages, I felt they were clogging up the code a lot. It's still quite a long .js file, it might be good to split up functionality into several files and/or classe, and to add proper logging/error handling to replace the removed comments and such. 